### PR TITLE
Refactored status string to individual widget for each metric

### DIFF
--- a/lib/screens/power_table_screen.dart
+++ b/lib/screens/power_table_screen.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:fl_chart/fl_chart.dart';
 import '../utils/bledata.dart';
+import '../widgets/metric_card.dart';
 
 class PowerTableScreen extends StatefulWidget {
   final BluetoothDevice device;
@@ -103,11 +104,6 @@ class _PowerTableScreenState extends State<PowerTableScreen> {
     }
     _refreshBlocker = true;
     await Future.delayed(Duration(microseconds: 500));
-    statusString = bleData.ftmsData.watts.toString() +
-        "w   " +
-        bleData.ftmsData.cadence.toString() +
-        "rpm " +
-        (bleData.ftmsData.heartRate == 0 ? "" : bleData.ftmsData.heartRate.toString() + "bpm ");
     if (mounted) {
       setState(() {});
     }
@@ -133,12 +129,42 @@ class _PowerTableScreenState extends State<PowerTableScreen> {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: <Widget>[
-            Text(
-              statusString,
-              style: TextStyle(
-                fontSize: 25,
-                fontWeight: FontWeight.bold,
-                letterSpacing: 2,
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  if (bleData.simulatedTargetWatts != "")
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: MetricBox(
+                        value: bleData.simulatedTargetWatts.toString(),
+                        label: 'Target Watts',
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: MetricBox(
+                      value: bleData.ftmsData.watts.toString(),
+                      label: 'Watts',
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: MetricBox(
+                      value: bleData.ftmsData.cadence.toString(),
+                      label: 'RPM',
+                    ),
+                  ),
+                  if (bleData.ftmsData.heartRate != 0)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: MetricBox(
+                        value: bleData.ftmsData.heartRate.toString(),
+                        label: 'BPM',
+                      ),
+                    )
+                ],
               ),
             ),
             Expanded(

--- a/lib/utils/bledata.dart
+++ b/lib/utils/bledata.dart
@@ -76,6 +76,7 @@ class BLEData {
   bool configAppCompatibleFirmware = false;
   bool isUpdatingFirmware = false;
   String firmwareVersion = "";
+  String simulatedTargetWatts = "";
 
   List<List<int?>> powerTableData = List.generate(
     10,
@@ -555,9 +556,12 @@ class BLEData {
                     c["value"] = noFirmSupport;
                   } else {
                     c["value"] = data.getInt16(2, Endian.little).toString();
+                    simulatedTargetWatts = (c["reference"] == "0x28") ? c["value"] : simulatedTargetWatts;
                   }
+
                   break;
                 }
+
               case "bool":
                 {
                   String b = (value[2] == 0) ? "false" : "true";

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -64,6 +64,8 @@ final String maxBrakeWattsVname = "BLE_maxBrakeWatts";
 final String scanBLEVname = "BLE_scanBLE";
 final String resetPowerTableVname = "BLE_resetPowerTable";
 final String powerTableDataVname = "BLE_powerTableData";
+final String simulatedTargetWattsVname = "BLE_simulatedTargetWatts";
+final String simulateTargetWattsVname = "BLE_simulateTargetWatts";
 
 // Refactored customCharacteristicFramework to directly use Dart map
 final dynamic customCharacteristicFramework = [
@@ -507,6 +509,28 @@ final dynamic customCharacteristicFramework = [
     "min": -32768,
     "max": 32768,
     "textDescription": "Read or Write Data to the Power Table",
+    "defaultData": "false"
+  },
+  {
+    "vName": simulatedTargetWattsVname,
+    "reference": "0x28",
+    "isSetting": false,
+    "type": "int",
+    "humanReadableName": "Target Watts",
+    "min": 0,
+    "max": 2000,
+    "textDescription": "Your target watt output.",
+    "defaultData": "0"
+  },
+  {
+    "vName": simulateTargetWattsVname,
+    "reference": "0x29",
+    "isSetting": false,
+    "type": "bool",
+    "humanReadableName": "Target Simulate Watts",
+    "min": 0,
+    "max": 1,
+    "textDescription": "Enable to generate simulated target watt data.",
     "defaultData": "false"
   }
 ];

--- a/lib/widgets/metric_card.dart
+++ b/lib/widgets/metric_card.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+class MetricBox extends StatefulWidget {
+  final String value;
+  final String label;
+
+  const MetricBox({
+    Key? key,
+    this.value = '',
+    required this.label,
+  }) : super(key: key);
+
+  @override
+  _MetricBoxState createState() => _MetricBoxState();
+}
+
+class _MetricBoxState extends State<MetricBox> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 65,
+      height: 65,
+      decoration: BoxDecoration(
+        color: const Color.fromARGB(255, 188, 22, 19),
+        borderRadius: BorderRadius.circular(14.0),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            widget.value,
+            style: const TextStyle(
+              fontSize: 22,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 4.0),
+          Text(
+            widget.label,
+            style: const TextStyle(
+              fontSize: 9,
+              color: Colors.white,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Added Metric Box widget to display metrics (Watts, target watts, cadence, etc.), and updated power table to use this widget for its display rather than a status string.